### PR TITLE
Template functional update to v1.3.8 + cache hardening

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   update-citations:
     uses: ./.github/workflows/update-citations.yaml
+    secrets: inherit
 
   build-preview:
     needs: update-citations

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -18,6 +18,7 @@ jobs:
     # skip first run because nothing enabled or setup yet
     if: github.run_number != 1
     uses: ./.github/workflows/update-citations.yaml
+    secrets: inherit
 
   build-site:
     needs: update-citations

--- a/.github/workflows/on-schedule.yaml
+++ b/.github/workflows/on-schedule.yaml
@@ -18,5 +18,6 @@ jobs:
     # only run on user instance of template, not template itself
     if: github.repository != 'greenelab/lab-website-template'
     uses: ./.github/workflows/update-citations.yaml
+    secrets: inherit
     with:
       open-pr: true

--- a/.github/workflows/update-citations.yaml
+++ b/.github/workflows/update-citations.yaml
@@ -61,13 +61,6 @@ jobs:
         run: python _cite/cite.py
         timeout-minutes: 15
 
-      - name: Commit cache
-        if: failure()
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          file_pattern: "**/.cache/**"
-          commit_message: "Commit cache"
-
       - name: Check if citations changed
         if: github.event.action != 'closed'
         id: changed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 # citation metadata for the template itself
 
 title: "Lab Website Template"
-version: 1.3.7
-date-released: 2025-07-31
+version: 1.3.8
+date-released: 2025-11-17
 url: "https://github.com/greenelab/lab-website-template"
 authors:
   - family-names: "Rubinetti"

--- a/_cite/plugins/orcid.py
+++ b/_cite/plugins/orcid.py
@@ -84,6 +84,10 @@ def main(entry):
         id_type = get_safe(_id, "external-id-type", "")
         id_value = get_safe(_id, "external-id-value", "")
 
+        # if no available ids, skip source completely
+        # if not id_type or not id_value:
+        #     continue
+
         # create source
         source = {}
 


### PR DESCRIPTION
## Summary
- Apply functional template updates from greenelab/lab-website-template v1.3.8
- Keep lab-specific README.md unchanged
- Update CITATION.cff template metadata to version 1.3.8 and date-released 2025-11-17
- Harden citation workflow by removing cache auto-commit on failure

## Files Updated
- .github/workflows/on-pull-request.yaml
- .github/workflows/on-push.yaml
- .github/workflows/on-schedule.yaml
- _cite/plugins/orcid.py
- .github/workflows/update-citations.yaml
- CITATION.cff

## Notes
- This is a functional-only template bump.
- README.md intentionally not synced from template.
- Cache hardening prevents re-committing transient .cache artifacts during failure scenarios.
